### PR TITLE
Fix/SKU reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- `refId` in `skuReferenceId` used as object instead of array
+
 ## [0.2.0] - 2020-09-21
 ### Fixed
 - Messages path typo

--- a/react/ProductIdentifierProduct.tsx
+++ b/react/ProductIdentifierProduct.tsx
@@ -29,7 +29,7 @@ const allowedIdFields: Record<
     if (!refIds) {
       return null
     }
-        
+
     const refId = refIds.find(({ Key }) => Key === 'RefId')
 
     if (!refId) {

--- a/react/ProductIdentifierProduct.tsx
+++ b/react/ProductIdentifierProduct.tsx
@@ -29,7 +29,7 @@ const allowedIdFields: Record<
     if (!refIds) {
       return null
     }
-
+        
     const refId = refIds.find(({ Key }) => Key === 'RefId')
 
     if (!refId) {

--- a/react/ProductIdentifierSummary.tsx
+++ b/react/ProductIdentifierSummary.tsx
@@ -58,7 +58,7 @@ const ProductIdentifierSummary: StorefrontFunctionComponent<
   ProductIdentifierProductProps
 > = ({ idField, customLabel, label }) => {
   const context = useProductSummary()
-  
+
   const sanitizedId = sanitizeId(idField) as IdField
 
   if (

--- a/react/ProductIdentifierSummary.tsx
+++ b/react/ProductIdentifierSummary.tsx
@@ -58,6 +58,7 @@ const ProductIdentifierSummary: StorefrontFunctionComponent<
   ProductIdentifierProductProps
 > = ({ idField, customLabel, label }) => {
   const context = useProductSummary()
+  
   const sanitizedId = sanitizeId(idField) as IdField
 
   if (

--- a/react/ProductIdentifierSummary.tsx
+++ b/react/ProductIdentifierSummary.tsx
@@ -56,9 +56,8 @@ const sanitizeId = (idField: string): IdField => {
 
 const ProductIdentifierSummary: StorefrontFunctionComponent<
   ProductIdentifierProductProps
-> = ({ idField, customLabel}) => {
-  const context = useProductSummary() 
-  
+> = ({ idField, customLabel, label }) => {
+  const context = useProductSummary()
   const sanitizedId = sanitizeId(idField) as IdField
 
   if (
@@ -72,14 +71,14 @@ const ProductIdentifierSummary: StorefrontFunctionComponent<
     return null
   }
 
-  const value = allowedIdFields[sanitizedId](context)  
+  const value = allowedIdFields[sanitizedId](context)
 
   return (
     <BaseProductIdentifier
       idField={idField}
       value={value}
       customLabel={customLabel}
-      label='custom'
+      label={label}
     />
   )
 }

--- a/react/ProductIdentifierSummary.tsx
+++ b/react/ProductIdentifierSummary.tsx
@@ -27,7 +27,7 @@ const allowedIdFields: Record<
   },
   skuReferenceId: context => {
     // TODO: Add `selectedSku` to ProductSummaryContext instead of using `sku`
-    const refIds =
+    const refId =
       context &&
       context.product &&
       context.product.sku &&
@@ -35,17 +35,17 @@ const allowedIdFields: Record<
         ? context.product.sku.referenceId
         : null
 
-    if (!refIds) {
-      return null
-    }
-
-    const refId = refIds.find(({ Value }) => Value)
-
     if (!refId) {
       return null
     }
 
-    return refId.Value
+    const { Value } = refId
+
+    if (!Value) {
+      return null
+    }
+
+    return Value
   },
 }
 
@@ -56,9 +56,9 @@ const sanitizeId = (idField: string): IdField => {
 
 const ProductIdentifierSummary: StorefrontFunctionComponent<
   ProductIdentifierProductProps
-> = ({ idField, customLabel, label }) => {
-  const context = useProductSummary()
-
+> = ({ idField, customLabel}) => {
+  const context = useProductSummary() 
+  
   const sanitizedId = sanitizeId(idField) as IdField
 
   if (
@@ -72,14 +72,14 @@ const ProductIdentifierSummary: StorefrontFunctionComponent<
     return null
   }
 
-  const value = allowedIdFields[sanitizedId](context)
+  const value = allowedIdFields[sanitizedId](context)  
 
   return (
     <BaseProductIdentifier
       idField={idField}
       value={value}
       customLabel={customLabel}
-      label={label}
+      label='custom'
     />
   )
 }

--- a/react/package.json
+++ b/react/package.json
@@ -26,7 +26,7 @@
     "eslint-config-vtex-react": "^4.1.0",
     "prettier": "^1.18.2",
     "tslint-eslint-rules": "^5.4.0",
-    "typescript": "3.5.2"
+    "typescript": "3.9.7"
   },
   "version": "0.2.0"
 }

--- a/react/typings/vtex.product-summary-context.d.ts
+++ b/react/typings/vtex.product-summary-context.d.ts
@@ -10,7 +10,7 @@ declare module 'vtex.product-summary-context/ProductSummaryContext' {
 
   interface Item {
     itemId: string
-    referenceId: Reference[]
+    referenceId: Reference
   }
 
   interface Reference {

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -5108,10 +5108,10 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
-typescript@3.5.2:
-  version "3.5.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.2.tgz#a09e1dc69bc9551cadf17dba10ee42cf55e5d56c"
-  integrity sha512-7KxJovlYhTX5RaRbUdkAXN1KUZ8PwWlTzQdHV6xNqvuFOs7+WBo10TQUqT19Q/Jz2hk5v9TQDIhyLhhJY4p5AA==
+typescript@3.9.7:
+  version "3.9.7"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
+  integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==
 
 typescript@^3.3.3333:
   version "3.4.3"


### PR DESCRIPTION
#### What problem is this solving?

SKU referente id was returning as an object instead of an array in summary reference, so, when using "find" in an object, we were having a break in render

#### How to test it?

In home page you will see the sku reference id in shelf "novidades"


[Workspace](https://devconfig--reidosestojos.myvtex.com)

#### Screenshots or example usage:

![image](https://user-images.githubusercontent.com/13649073/97344280-4dbf1a80-1867-11eb-84be-a270da2e9bee.png)

#### How does this PR make you feel? [:link:](http://giphy.com/)

![](https://media.giphy.com/media/AeUcmWquAI8tW/giphy.gif)
